### PR TITLE
Support ssl for haproxy loadbalacer for cloudstack

### DIFF
--- a/src/config/svc-monitor/svc_monitor/services/loadbalancer/drivers/ha_proxy/driver.py
+++ b/src/config/svc-monitor/svc_monitor/services/loadbalancer/drivers/ha_proxy/driver.py
@@ -462,7 +462,7 @@ class OpencontrailLoadbalancerDriver(
         lb = LoadbalancerSM.get(lb_id)
         if not lb:
             return
-        if not lb.device_owner or lb.device_owner != 'K8S:LOADBALANCER':
+        if not lb.device_owner or (lb.device_owner != 'K8S:LOADBALANCER' and lb.device_owner != 'CS:LOADBALANCER'):
             self.update_vmi_fat_flows(lb.virtual_machine_interface,
                 self.get_port_list_v2(lb))
         conf = haproxy_config.get_config_v2(lb)
@@ -490,6 +490,9 @@ class OpencontrailLoadbalancerDriver(
         si_obj.add_service_instance_bindings(kvp)
         if device_owner and device_owner == 'K8S:LOADBALANCER':
             kvp = KeyValuePair('orchestrator', 'kubernetes')
+            si_obj.add_service_instance_bindings(kvp)
+        if device_owner and device_owner == 'CS:LOADBALANCER':
+            kvp = KeyValuePair('orchestrator', 'cloudstack')
             si_obj.add_service_instance_bindings(kvp)
         try:
             self._api.service_instance_update(si_obj)

--- a/src/vnsw/opencontrail-vrouter-netns/opencontrail_vrouter_netns/cert_mgr/cert_manager.py
+++ b/src/vnsw/opencontrail-vrouter-netns/opencontrail_vrouter_netns/cert_mgr/cert_manager.py
@@ -13,6 +13,11 @@ try:
 except ImportError:
     pass
 
+try:
+    from .cloudstack_cert_manager import CloudstackCertManager
+except ImportError:
+    pass
+
 class CertManager(object):
 
     def __init__(self):
@@ -25,6 +30,9 @@ class CertManager(object):
             if provider == 'barbican':
                 updated_config = (BarbicanCertManager(auth_conf)). \
                     update_ssl_config(haproxy_config, dest_dir)
+        elif orchestrator == 'cloudstack':
+            updated_config = (CloudstackCertManager(auth_conf)). \
+                update_ssl_config(haproxy_config, dest_dir)
         elif orchestrator == 'kubernetes':
             updated_config = (KubernetesCert(auth_conf)). \
                 update_ssl_config(haproxy_config, dest_dir)

--- a/src/vnsw/opencontrail-vrouter-netns/opencontrail_vrouter_netns/cert_mgr/cloudstack_cert_manager.py
+++ b/src/vnsw/opencontrail-vrouter-netns/opencontrail_vrouter_netns/cert_mgr/cloudstack_cert_manager.py
@@ -1,0 +1,92 @@
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import object
+import os
+from six.moves import configparser
+import logging
+import exceptions
+
+import requests
+import json
+import base64
+
+from .tls import TLS
+
+class CloudstackCertManager(object):
+
+    def __init__(self, auth_conf=None):
+        if auth_conf:
+            self.auth_conf = auth_conf
+        else:
+            self.auth_conf = '/etc/contrail/contrail-lbaas-auth.conf'
+        self.parse_args()
+
+        self.headers = {'Connection': 'Keep-Alive'}
+        self.verify = False
+        self.baseurl = "%s://%s:%s/%s/api" % (self.cloudstack_api_protocol,
+                                   self.cloudstack_api_server,
+                                   self.cloudstack_api_port,
+                                   self.cloudstack_api_context)
+
+    def parse_args(self):
+        config = configparser.SafeConfigParser()
+        config.read(self.auth_conf)
+
+        self.cloudstack_api_protocol = config.get('CLOUDSTACK', 'cloudstack_api_protocol')
+        self.cloudstack_api_server = config.get('CLOUDSTACK', 'cloudstack_api_server')
+        self.cloudstack_api_port = config.get('CLOUDSTACK', 'cloudstack_api_port')
+        self.cloudstack_api_context = config.get('CLOUDSTACK', 'cloudstack_api_context')
+
+    def get_resource(self, params):
+        json_data = {}
+        url = "%s?%s" % (self.baseurl, params)
+        try:
+            resp = requests.get(url, stream=True, \
+                                headers=self.headers, verify=self.verify)
+            if resp.status_code == 200:
+                json_data = json.loads(resp.content)
+            resp.close()
+        except requests.exceptions.RequestException as e:
+            msg = "Error in getting data from cloudstack : %s" %(e)
+            logging.exception(msg)
+
+        return json_data
+
+    def get_tls_certificates(self, params):
+        try:
+            json = self.get_resource(params)
+            data = json['getloadbalancersslcertificateresponse']['data']
+        except exceptions.Exception as e:
+            msg = "Error in getting data from %s" %(params)
+            logging.exception(msg)
+            return None
+        certificate = base64.b64decode(data['crt'])
+        private_key = base64.b64decode(data['key'])
+        intermediates = base64.b64decode(data['chain'])
+        primary_cn = TLS.get_primary_cn(certificate)
+        return TLS(
+            primary_cn=primary_cn,
+            private_key=private_key,
+            certificate=certificate,
+            intermediates=intermediates)
+
+    def update_ssl_config(self, haproxy_config, dest_dir):
+        updated_config = haproxy_config
+        for line in haproxy_config.split('\n'):
+            if 'ssl crt' in line:
+                try:
+                    items = [x for x in line.split(' ') if x.startswith('crt__')]
+                except IndexError:
+                    return None
+                for item in items or []:
+                    url = item[5:]
+                    tls = self.get_tls_certificates(url)
+                    if tls is None:
+                        return None
+                    pem_file_name = tls.create_pem_file(dest_dir)
+                    if pem_file_name is None:
+                        return None
+                    updated_config = updated_config.replace(item, 'crt ' + pem_file_name)
+
+        return updated_config

--- a/src/vnsw/opencontrail-vrouter-netns/opencontrail_vrouter_netns/contrail-lbaas-auth.conf
+++ b/src/vnsw/opencontrail-vrouter-netns/opencontrail_vrouter_netns/contrail-lbaas-auth.conf
@@ -5,3 +5,9 @@
 #admin_password=contrail123
 #auth_url=http://ip:35357/v2.0
 #region=RegionOne
+
+[CLOUDSTACK]
+#cloudstack_api_protocol=http
+#cloudstack_api_server=127.0.0.1
+#cloudstack_api_port=8080
+#cloudstack_api_context=client


### PR DESCRIPTION
https://jira.tungsten.io/browse/TFP-110

Currently, tungsten fabric is only support terminated https haproxy
load balancer for openstack and k8. Need to support for cloudstack also

Add feature to support terminated https haproxy load balancer for
cloudstack